### PR TITLE
Replace broken git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ TodoApi is a web service created in .NET Core 2.1, PostgreSQL 10 &amp; Visual St
     (verify this by executing `$ dotnet` on your terminal - you should see output text)
 2. Get [Visual Studio](https://visualstudio.microsoft.com/)
 3. Clone this repo with: 
-    `$ git clone git@github.com:makersacademy/TodoApi.git`
+    `$ git clone https://github.com/makersacademy/TodoApi`
 4. Open folder TodoApi in your Visual Studio editor, and double click on `TodoApi.csproj`
 5. Install postgres (if you haven't got it already) with 
     `$ brew install postgresql` and start with


### PR DESCRIPTION
Output of previous command:
```
$ git clone git@github.com:makersacademy/TodoApi.git
Cloning into 'TodoApi'...
The authenticity of host 'github.com (140.82.118.4)' can't be established.
RSA key fingerprint is
```
[redacted].
```
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,140.82.118.4' (RSA) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
Please make sure you have the correct access rights
and the repository exists.
```
